### PR TITLE
Start grabbing GTFS data from FGB files on the web

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -117,6 +117,7 @@ dependencies = [
  "serde-wasm-bindgen",
  "serde_json",
  "simple_logger",
+ "tokio",
  "utils",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -699,6 +700,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
 name = "home"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1002,6 +1009,16 @@ checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -1699,9 +1716,22 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "num_cpus",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -66,6 +75,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,7 +106,7 @@ dependencies = [
  "fast_paths",
  "flatgeobuf",
  "geo",
- "geojson 0.24.1 (git+https://github.com/georust/geojson)",
+ "geojson",
  "geozero",
  "js-sys",
  "log",
@@ -99,9 +119,31 @@ dependencies = [
  "simple_logger",
  "utils",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
  "web-sys",
  "web-time",
 ]
+
+[[package]]
+name = "backtrace"
+version = "0.3.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "bincode"
@@ -144,6 +186,12 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cc"
@@ -211,6 +259,16 @@ dependencies = [
  "lazy_static",
  "rustc-hash",
  "slab",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -328,6 +386,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "enum-map"
 version = "2.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,10 +481,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b9fd319b3db16586172a3aceaa21b328999887f8b4535d4f06296138f92880"
 dependencies = [
  "byteorder",
+ "bytes",
  "fallible-streaming-iterator",
  "flatbuffers",
  "geozero",
+ "http-range-client",
  "log",
+ "reqwest",
  "tempfile",
 ]
 
@@ -426,6 +496,75 @@ name = "float_next_after"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+
+[[package]]
+name = "futures-task"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+
+[[package]]
+name = "futures-util"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+]
 
 [[package]]
 name = "generic-array"
@@ -478,18 +617,6 @@ dependencies = [
 [[package]]
 name = "geojson"
 version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d728c1df1fbf328d74151efe6cb0586f79ee813346ea981add69bd22c9241b"
-dependencies = [
- "log",
- "serde",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
-name = "geojson"
-version = "0.24.1"
 source = "git+https://github.com/georust/geojson#6805f466a8781016070726c8c88311110032565f"
 dependencies = [
  "geo-types",
@@ -505,10 +632,35 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cd8fb67347739a057fd607b6d8b43ba4ed93619ed84b8f429fa3296f8ae504c"
 dependencies = [
- "geojson 0.24.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "geo-types",
  "log",
  "serde_json",
  "thiserror",
+]
+
+[[package]]
+name = "gimli"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+
+[[package]]
+name = "h2"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap 2.2.6",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -556,6 +708,91 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-range-client"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c724cf94381bf0f09a60c980ae732d1f2859ee2a98a0d6bce68ae509f915785c"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "read-logger",
+ "reqwest",
+ "thiserror",
+]
+
+[[package]]
+name = "httparse"
+version = "1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "0.14.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f361cde2f109281a220d4307746cdfd5ee3f410da58a70377762396775634b33"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,6 +816,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "idna"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,6 +844,12 @@ dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "itertools"
@@ -677,12 +930,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -708,6 +978,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -715,6 +1002,15 @@ checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "object"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "576dfe1fc8f9df304abb159d767a29d0476f7750fbf8aa7ad07816004a207434"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -748,6 +1044,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl"
+version = "0.10.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
+dependencies = [
+ "bitflags 2.4.1",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "osm-reader"
 version = "0.1.0"
 source = "git+https://github.com/a-b-street/osm-reader#e857c5e899219b4430e612595ee5cdfe6b59054d"
@@ -771,6 +1111,12 @@ dependencies = [
  "protobuf-codegen",
  "rayon",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
@@ -816,6 +1162,24 @@ dependencies = [
  "pest",
  "sha2",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "priority-queue"
@@ -918,6 +1282,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "read-logger"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7f715a23c7db804b71eb9162a9cf210b89e99db9c3649a2a038d13b7594a99"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -956,6 +1329,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
+name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
 name = "robust"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -978,6 +1391,12 @@ dependencies = [
  "serde",
  "smallvec",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
@@ -1008,16 +1427,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
+name = "schannel"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -1068,6 +1528,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1104,6 +1576,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
+name = "socket2"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "spade"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1130,6 +1612,33 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1166,6 +1675,90 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c55115c6fbe2d2bef26eb09ad74bde02d8255476fc0c7b515ef09fbb35742d82"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
+dependencies = [
+ "backtrace",
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+
+[[package]]
+name = "tracing"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1178,10 +1771,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "url"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
 
 [[package]]
 name = "utils"
@@ -1197,10 +1816,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
@@ -1225,6 +1865,18 @@ dependencies = [
  "quote",
  "syn",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1428,6 +2080,16 @@ name = "windows_x86_64_msvc"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "zerocopy"

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -84,8 +84,10 @@ dependencies = [
  "csv",
  "enum-map",
  "fast_paths",
+ "flatgeobuf",
  "geo",
- "geojson",
+ "geojson 0.24.1 (git+https://github.com/georust/geojson)",
+ "geozero",
  "js-sys",
  "log",
  "muv-osm",
@@ -145,9 +147,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.0.95"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
+checksum = "ac367972e516d45567c7eafc73d24e1c193dcf200a8d94e9db7b3d38b349572d"
 
 [[package]]
 name = "cfg-if"
@@ -363,6 +365,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fast_paths"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -380,6 +388,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
+name = "flatbuffers"
+version = "23.5.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dac53e22462d78c16d64a1cd22371b54cc3fe94aa15e7886a2fa6e5d1ab8640"
+dependencies = [
+ "bitflags 1.3.2",
+ "rustc_version",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,6 +405,20 @@ checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "flatgeobuf"
+version = "4.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b9fd319b3db16586172a3aceaa21b328999887f8b4535d4f06296138f92880"
+dependencies = [
+ "byteorder",
+ "fallible-streaming-iterator",
+ "flatbuffers",
+ "geozero",
+ "log",
+ "tempfile",
 ]
 
 [[package]]
@@ -446,11 +478,35 @@ dependencies = [
 [[package]]
 name = "geojson"
 version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d728c1df1fbf328d74151efe6cb0586f79ee813346ea981add69bd22c9241b"
+dependencies = [
+ "log",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "geojson"
+version = "0.24.1"
 source = "git+https://github.com/georust/geojson#6805f466a8781016070726c8c88311110032565f"
 dependencies = [
  "geo-types",
  "log",
  "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "geozero"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cd8fb67347739a057fd607b6d8b43ba4ed93619ed84b8f429fa3296f8ae504c"
+dependencies = [
+ "geojson 0.24.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log",
  "serde_json",
  "thiserror",
 ]
@@ -930,6 +986,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -953,6 +1018,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -110,6 +110,7 @@ dependencies = [
  "geozero",
  "js-sys",
  "log",
+ "miniz_oxide",
  "muv-osm",
  "osm-reader",
  "rstar",
@@ -944,9 +945,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.1"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
 ]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -16,8 +16,10 @@ chrono = { version = "0.4.33", default-features = false, features = ["serde"] }
 csv = "1.3.0"
 enum-map = { version = "2.7.3", features = ["serde"] }
 fast_paths = "1.0.0"
+flatgeobuf = "4.2.1"
 geo = "0.28.0"
 geojson = { git = "https://github.com/georust/geojson", features = ["geo-types"] }
+geozero = { version = "0.13.0", default-features = false, features = ["with-geo"] }
 js-sys = "0.3.69"
 log = "0.4.20"
 muv-osm = { git = "https://gitlab.com/LeLuxNet/Muv", features = ["lanes"] }
@@ -29,10 +31,9 @@ serde-wasm-bindgen = "0.6.0"
 simple_logger = { version = "5.0.0", default-features = false }
 utils = { git = "https://github.com/a-b-street/utils", features = ["serde"] }
 wasm-bindgen = "0.2.87"
+wasm-bindgen-futures = "0.4.42"
 web-sys = { version = "0.3.64", features = ["console"] }
 web-time = "1.1.0"
-flatgeobuf = { version = "4.2.1", default-features = false }
-geozero = { version = "0.13.0", default-features = false, features = ["with-geojson"] }
 
 # For local development, build dependencies in release mode once, but otherwise
 # use dev profile and avoid wasm-opt.

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -35,6 +35,9 @@ wasm-bindgen-futures = "0.4.42"
 web-sys = { version = "0.3.64", features = ["console"] }
 web-time = "1.1.0"
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { version = "1.38.0", features = ["macros", "rt-multi-thread"] }
+
 # For local development, build dependencies in release mode once, but otherwise
 # use dev profile and avoid wasm-opt.
 [profile.dev.package."*"]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -31,6 +31,8 @@ utils = { git = "https://github.com/a-b-street/utils", features = ["serde"] }
 wasm-bindgen = "0.2.87"
 web-sys = { version = "0.3.64", features = ["console"] }
 web-time = "1.1.0"
+flatgeobuf = { version = "4.2.1", default-features = false }
+geozero = { version = "0.13.0", default-features = false, features = ["with-geojson"] }
 
 # For local development, build dependencies in release mode once, but otherwise
 # use dev profile and avoid wasm-opt.

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -34,6 +34,7 @@ wasm-bindgen = "0.2.87"
 wasm-bindgen-futures = "0.4.42"
 web-sys = { version = "0.3.64", features = ["console"] }
 web-time = "1.1.0"
+miniz_oxide = "0.7.4"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1.38.0", features = ["macros", "rt-multi-thread"] }

--- a/backend/src/gtfs/fgb.rs
+++ b/backend/src/gtfs/fgb.rs
@@ -1,0 +1,83 @@
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::io::BufWriter;
+
+use anyhow::Result;
+use chrono::NaiveTime;
+use flatgeobuf::geozero::geojson::GeoJsonString;
+use flatgeobuf::{FgbWriter, GeometryType};
+use geo::LineString;
+use geojson::{Feature, Geometry};
+use serde::Serialize;
+
+use super::{orig_ids, GtfsModel, Route, StopID};
+
+impl GtfsModel {
+    pub fn to_fgb(&self, filename: &str) -> Result<()> {
+        let mut fgb = FgbWriter::create("gtfs", GeometryType::LineString)?;
+        // TODO json col
+
+        for (variant, linestring) in group_variants(self) {
+            // TODO Is there a way to avoid this round-trip?
+            let mut f = Feature::from(Geometry::from(&linestring));
+            f.set_property("data", serde_json::to_value(&variant)?);
+            fgb.add_feature(GeoJsonString(serde_json::to_string(&f)?))?;
+        }
+
+        let mut out = BufWriter::new(File::create(filename)?);
+        fgb.write(&mut out)?;
+        println!("Wrote {filename}");
+        Ok(())
+    }
+
+    // TODO Will need to clip to a map later
+}
+
+#[derive(Serialize)]
+struct RouteVariant {
+    // Per stop, (original ID and name)
+    pub stop_info: Vec<(orig_ids::StopID, String)>,
+
+    // Each one has an arrival time per stop
+    pub trips: Vec<Vec<NaiveTime>>,
+
+    // Metadata
+    pub route: Route,
+}
+
+// In GTFS, routes contain many trips, each with a stop sequence. But there are really "variants"
+// of stop sequences. We need to group by those.
+fn group_variants(gtfs: &GtfsModel) -> Vec<(RouteVariant, LineString)> {
+    let mut variants: BTreeMap<Vec<StopID>, (RouteVariant, LineString)> = BTreeMap::new();
+
+    for trip in &gtfs.trips {
+        let stop_sequence: Vec<StopID> = trip.stop_sequence.iter().map(|(s, _)| *s).collect();
+        let trip_times = trip.stop_sequence.iter().map(|(_, t)| *t).collect();
+
+        variants
+            .entry(stop_sequence.clone())
+            .or_insert_with(|| {
+                let mut stop_info = Vec::new();
+                let mut pts = Vec::new();
+                for s in &stop_sequence {
+                    let stop = &gtfs.stops[s.0];
+                    stop_info.push((stop.orig_id.clone(), stop.name.clone()));
+                    pts.push(stop.point.into());
+                }
+
+                (
+                    RouteVariant {
+                        stop_info,
+                        trips: Vec::new(),
+                        route: gtfs.routes[trip.route.0].clone(),
+                    },
+                    LineString::new(pts),
+                )
+            })
+            .0
+            .trips
+            .push(trip_times);
+    }
+
+    variants.into_values().collect()
+}

--- a/backend/src/gtfs/mod.rs
+++ b/backend/src/gtfs/mod.rs
@@ -10,6 +10,7 @@ use self::ids::orig_ids;
 pub use self::ids::{RouteID, StopID, TripID};
 use crate::graph::RoadID;
 
+mod fgb;
 mod ids;
 mod scrape;
 
@@ -33,6 +34,7 @@ pub struct Stop {
     pub next_steps: Vec<NextStep>,
 }
 
+// TODO Detangle and make it more clear what's serialized and what's derived
 /// `trip` arrives at some `Stop` at `time`. Then it reaches `stop2` at `time2`
 #[derive(Serialize, Deserialize)]
 pub struct NextStep {
@@ -49,7 +51,7 @@ pub struct Trip {
     pub route: RouteID,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Route {
     pub orig_id: orig_ids::RouteID,
     pub short_name: Option<String>,

--- a/backend/src/gtfs/scrape.rs
+++ b/backend/src/gtfs/scrape.rs
@@ -171,7 +171,7 @@ impl GtfsModel {
         Ok(model)
     }
 
-    fn precompute_next_steps(&mut self) {
+    pub(crate) fn precompute_next_steps(&mut self) {
         for (idx, trip) in self.trips.iter().enumerate() {
             let trip_id = TripID(idx);
             for pair in trip.stop_sequence.windows(2) {

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -13,6 +13,7 @@ use serde::Deserialize;
 use wasm_bindgen::prelude::*;
 
 pub use graph::{Graph, Mode};
+pub use gtfs::GtfsModel;
 pub use timer::Timer;
 
 mod amenity;

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -58,7 +58,8 @@ impl MapModel {
             None => GtfsSource::None,
         };
         let graph = if is_osm {
-            Graph::new(input_bytes, gtfs, Timer::new("build graph", progress_cb)).await
+            Graph::new(input_bytes, gtfs, Timer::new("build graph", progress_cb))
+                .await
                 .map_err(err_to_js)?
         } else {
             bincode::deserialize_from(input_bytes).map_err(err_to_js)?

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -3,14 +3,15 @@ use std::io::BufWriter;
 
 use anyhow::Result;
 
-use backend::{Graph, Timer};
+use backend::{GtfsSource, Graph, Timer};
 
 /// This is a CLI tool to build a Graph file with GTFS data, for later use in the web app. This
 /// gives a perf benefit (faster to load a pre-built graph) and allows GTFS use (no practical way
 /// to read a huge GTFS file or clip it from web). The downside is having to manually manage these
 /// prebuilt files as the format changes -- which is why, unlike in A/B Street, this'll just be for
 /// manual testing for now.
-fn main() -> Result<()> {
+// TODO I think I need tokio. But that means it's time to split crates, probably
+async fn main() -> Result<()> {
     simple_logger::SimpleLogger::new().init().unwrap();
 
     let args: Vec<String> = std::env::args().collect();
@@ -24,8 +25,12 @@ fn main() -> Result<()> {
     if args[1] == "graph" {
         let timer = Timer::new("build graph", None);
         let osm_bytes = std::fs::read(&args[2])?;
+        let gtfs = match args.get(3) {
+            Some(dir) => GtfsSource::Dir(dir.to_string()),
+            None => GtfsSource::None,
+        };
 
-        let graph = Graph::new(&osm_bytes, args.get(3), timer)?;
+        let graph = Graph::new(&osm_bytes, gtfs, timer).await?;
         let writer = BufWriter::new(File::create("graph.bin")?);
         bincode::serialize_into(writer, &graph)?;
     } else if args[1] == "fgb" {

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -3,14 +3,15 @@ use std::io::BufWriter;
 
 use anyhow::Result;
 
-use backend::{GtfsSource, Graph, Timer};
+use backend::{Graph, GtfsSource, Timer};
 
+// TODO Don't need tokio multithreading, but fighting config to get single working
 /// This is a CLI tool to build a Graph file with GTFS data, for later use in the web app. This
 /// gives a perf benefit (faster to load a pre-built graph) and allows GTFS use (no practical way
 /// to read a huge GTFS file or clip it from web). The downside is having to manually manage these
 /// prebuilt files as the format changes -- which is why, unlike in A/B Street, this'll just be for
 /// manual testing for now.
-// TODO I think I need tokio. But that means it's time to split crates, probably
+#[tokio::main]
 async fn main() -> Result<()> {
     simple_logger::SimpleLogger::new().init().unwrap();
 

--- a/backend/src/scrape.rs
+++ b/backend/src/scrape.rs
@@ -136,7 +136,7 @@ impl Graph {
         timer.push("setting up GTFS");
         timer.step("parse");
         let mut gtfs = if let Some(path) = gtfs_dir {
-            GtfsModel::parse(path, &graph.mercator)?
+            GtfsModel::parse(path, Some(&graph.mercator))?
         } else {
             GtfsModel::empty()
         };

--- a/backend/src/scrape.rs
+++ b/backend/src/scrape.rs
@@ -54,7 +54,11 @@ impl utils::osm2graph::OsmReader for ReadAmenities {
 
 impl Graph {
     /// Call with bytes of an osm.pbf or osm.xml string
-    pub async fn new(input_bytes: &[u8], gtfs_source: GtfsSource, mut timer: Timer) -> Result<Graph> {
+    pub async fn new(
+        input_bytes: &[u8],
+        gtfs_source: GtfsSource,
+        mut timer: Timer,
+    ) -> Result<Graph> {
         timer.step("parse OSM and split graph");
 
         let mut amenities = ReadAmenities {

--- a/web/src/title/MapLoader.svelte
+++ b/web/src/title/MapLoader.svelte
@@ -59,10 +59,12 @@
   }
 
   async function loadModel(buffer: ArrayBuffer) {
+    let gtfsUrl = useLocalVite ? "/gtfs.fgb" : undefined;
     loading = ["Building map model from OSM input"];
     console.time("load");
     await $backend!.loadOsmFile(
       new Uint8Array(buffer),
+      gtfsUrl,
       Comlink.proxy(progressCb),
     );
     console.timeEnd("load");

--- a/web/src/title/MapLoader.svelte
+++ b/web/src/title/MapLoader.svelte
@@ -59,8 +59,9 @@
   }
 
   async function loadModel(buffer: ArrayBuffer) {
-    // TODO Not sure on GH Pages yet; host remotely
-    let gtfsUrl = useLocalVite ? `http://${window.location.host}/15m/gtfs.fgb` : undefined;
+    let gtfsUrl = useLocalVite
+      ? `http://${window.location.host}/15m/gtfs.fgb`
+      : "https://od2net.org/gtfs.fgb";
     loading = ["Building map model from OSM input"];
     console.time("load");
     await $backend!.loadOsmFile(

--- a/web/src/title/MapLoader.svelte
+++ b/web/src/title/MapLoader.svelte
@@ -61,7 +61,7 @@
   async function loadModel(buffer: ArrayBuffer) {
     let gtfsUrl = useLocalVite
       ? `http://${window.location.host}/15m/gtfs.fgb`
-      : "https://od2net.org/gtfs.fgb";
+      : "https://assets.od2net.org/severance_pbfs/gtfs.fgb";
     loading = ["Building map model from OSM input"];
     console.time("load");
     await $backend!.loadOsmFile(

--- a/web/src/title/MapLoader.svelte
+++ b/web/src/title/MapLoader.svelte
@@ -59,7 +59,8 @@
   }
 
   async function loadModel(buffer: ArrayBuffer) {
-    let gtfsUrl = useLocalVite ? "/gtfs.fgb" : undefined;
+    // TODO Not sure on GH Pages yet; host remotely
+    let gtfsUrl = useLocalVite ? `http://${window.location.host}/15m/gtfs.fgb` : undefined;
     loading = ["Building map model from OSM input"];
     console.time("load");
     await $backend!.loadOsmFile(

--- a/web/src/worker.ts
+++ b/web/src/worker.ts
@@ -25,7 +25,7 @@ export class Backend {
     await init();
 
     // TODO Can we await here?
-    this.inner = new MapModel(osmBytes, true, gtfsUrl, progressCb);
+    this.inner = await new MapModel(osmBytes, true, gtfsUrl, progressCb);
   }
 
   async loadGraphFile(graphBytes: Uint8Array) {
@@ -34,7 +34,7 @@ export class Backend {
 
     // No progress worth reporting for this
     // TODO Can we await here?
-    this.inner = new MapModel(graphBytes, false, undefined, undefined);
+    this.inner = await new MapModel(graphBytes, false, undefined, undefined);
   }
 
   isLoaded(): boolean {

--- a/web/src/worker.ts
+++ b/web/src/worker.ts
@@ -16,11 +16,16 @@ export class Backend {
     this.inner = null;
   }
 
-  async loadOsmFile(osmBytes: Uint8Array, progressCb: (msg: string) => void) {
+  async loadOsmFile(
+    osmBytes: Uint8Array,
+    gtfsUrl: string | undefined,
+    progressCb: (msg: string) => void,
+  ) {
     // TODO Do we need to do this only once?
     await init();
 
-    this.inner = new MapModel(osmBytes, true, progressCb);
+    // TODO Can we await here?
+    this.inner = new MapModel(osmBytes, true, gtfsUrl, progressCb);
   }
 
   async loadGraphFile(graphBytes: Uint8Array) {
@@ -28,7 +33,8 @@ export class Backend {
     await init();
 
     // No progress worth reporting for this
-    this.inner = new MapModel(graphBytes, false, undefined);
+    // TODO Can we await here?
+    this.inner = new MapModel(graphBytes, false, undefined, undefined);
   }
 
   isLoaded(): boolean {


### PR DESCRIPTION
Part of #4. The approach is:

1) Offline, assemble one massive GTFS feed covering ideally the world. Right now, it's just the UK, thanks to https://data.bus-data.dft.gov.uk/.
2) Run a tool that extracts relevant info from the GTFS and expresses as a [flatgeobuf](http://flatgeobuf.org/) file
3) When the user imports an area on the web (dynamically from OSM data, thanks to the Overpass API), make the browser also query relevant areas of the FGB file and build the public transit graph too!

The "performance" is comically bad right now. Just the Elephant & Castle area triggers about 770 requests and sucks down 18MB. But not bad for a low-effort simple start!

The main missing thing is clipping; I'll try to add that now. Any trip intersecting the boundary area will have all stops included. So for part of central London, we wind up with stops very very far away:
![image](https://github.com/a-b-street/15m/assets/1664407/cd41e270-5851-4d5d-9d9f-dd30bbbae0fe)
This also messes up the routing.

Also before merging, I'll upload the FGB file and hook it up to the GH Pages demo... but maybe only if I can get the performance to be better, so I'm not burning through bandwidth ridiculously.

## Encoding

What's in the FGB file exactly? Per "route variant", a linestring, with one point per stop. (The full route shape isn't included yet.) What's a "route variant"? In GTFS, "route 5" has many trips, some of them with potentially different sequences of stops (like an express / weekend / full service). To express a route geometrically, we need to decide the stops included, so we use the sequence of stops as the primary key.

For each of these route variants with a linestring, some JSON-encoded data:
- per stop, its original GTFS ID and its human-friendly name
- the list of trips. Each trip is a list of arrival times at the stops. Right now encoded as strings like "03:53:00"
- some route metadata: GTFS ID, its long and short name, description