### PR TITLE
Switch from flatgeobuffer to geomedea for GTFS

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.22.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
 dependencies = [
  "gimli",
 ]
@@ -75,6 +75,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.11"
+source = "git+https://github.com/michaelkirk/async-compression?branch=mkirk/external-decoder#85721a11d58b6f26addb7b392c8163c880f043cf"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,14 +138,13 @@ dependencies = [
  "csv",
  "enum-map",
  "fast_paths",
- "flatgeobuf",
+ "futures-util",
  "geo",
  "geojson",
- "geozero",
+ "geomedea",
  "itertools 0.13.0",
  "js-sys",
  "log",
- "miniz_oxide",
  "muv-osm",
  "osm-reader",
  "rstar",
@@ -129,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.73"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
 dependencies = [
  "addr2line",
  "cc",
@@ -198,9 +231,13 @@ checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cc"
-version = "1.0.101"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac367972e516d45567c7eafc73d24e1c193dcf200a8d94e9db7b3d38b349572d"
+checksum = "17f6e324229dc011159fcc089755d1e2e216a90d43a7dea6853ca740b84f35e7"
+dependencies = [
+ "jobserver",
+ "libc",
+]
 
 [[package]]
 name = "cfg-if"
@@ -435,12 +472,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fallible-streaming-iterator"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
-
-[[package]]
 name = "fast_paths"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,16 +489,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
-name = "flatbuffers"
-version = "23.5.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dac53e22462d78c16d64a1cd22371b54cc3fe94aa15e7886a2fa6e5d1ab8640"
-dependencies = [
- "bitflags 1.3.2",
- "rustc_version",
-]
-
-[[package]]
 name = "flate2"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,23 +496,6 @@ checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
-]
-
-[[package]]
-name = "flatgeobuf"
-version = "4.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9fd319b3db16586172a3aceaa21b328999887f8b4535d4f06296138f92880"
-dependencies = [
- "byteorder",
- "bytes",
- "fallible-streaming-iterator",
- "flatbuffers",
- "geozero",
- "http-range-client",
- "log",
- "reqwest",
- "tempfile",
 ]
 
 [[package]]
@@ -546,6 +550,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
+name = "futures-io"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -564,9 +585,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -630,22 +656,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "geozero"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cd8fb67347739a057fd607b6d8b43ba4ed93619ed84b8f429fa3296f8ae504c"
+name = "geomedea"
+version = "0.3.0-beta.2"
+source = "git+https://github.com/michaelkirk/geomedea#127b96c9ee38b33cb9391876227626e7224df0b4"
 dependencies = [
- "geo-types",
+ "async-compression",
+ "async-stream",
+ "async-trait",
+ "bincode",
+ "byteorder",
+ "bytes",
+ "futures-util",
  "log",
- "serde_json",
+ "memmap2 0.9.4",
+ "ruzstd",
+ "serde",
+ "streaming-http-range-client",
+ "tempfile",
  "thiserror",
+ "tokio",
+ "zstd",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.29.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "h2"
@@ -736,20 +773,6 @@ dependencies = [
  "bytes",
  "http",
  "pin-project-lite",
-]
-
-[[package]]
-name = "http-range-client"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c724cf94381bf0f09a60c980ae732d1f2859ee2a98a0d6bce68ae509f915785c"
-dependencies = [
- "async-trait",
- "byteorder",
- "bytes",
- "read-logger",
- "reqwest",
- "thiserror",
 ]
 
 [[package]]
@@ -885,6 +908,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
+name = "jobserver"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -901,9 +933,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libm"
@@ -934,6 +966,15 @@ name = "memmap2"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memmap2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
 dependencies = [
  "libc",
 ]
@@ -1034,9 +1075,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.0"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "576dfe1fc8f9df304abb159d767a29d0476f7750fbf8aa7ad07816004a207434"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "memchr",
 ]
@@ -1134,7 +1175,7 @@ checksum = "8dbb2e170e56f11e0648dcb149d00b6fc27a205523303e11c4fd5820b246ba30"
 dependencies = [
  "byteorder",
  "flate2",
- "memmap2",
+ "memmap2 0.5.10",
  "protobuf",
  "protobuf-codegen",
  "rayon",
@@ -1310,15 +1351,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "read-logger"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7f715a23c7db804b71eb9162a9cf210b89e99db9c3649a2a038d13b7594a99"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1388,10 +1420,12 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "winreg",
 ]
@@ -1433,15 +1467,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustix"
 version = "0.38.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1461,6 +1486,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64",
+]
+
+[[package]]
+name = "ruzstd"
+version = "0.7.0"
+source = "git+https://github.com/michaelkirk/zstd-rs?branch=mkirk/fix-incremental-reads#75a86fdd03e25f01c1fbfabeaef615a737cbadd1"
+dependencies = [
+ "byteorder",
+ "twox-hash",
 ]
 
 [[package]]
@@ -1506,12 +1540,6 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
-
-[[package]]
-name = "semver"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
@@ -1630,6 +1658,28 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "streaming-http-range-client"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66ff5fba23ab8761b13d09408a99a1de5699bafa10725549031f642dda5f37d"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "log",
+ "reqwest",
+ "tokio",
+ "tokio-util",
+]
 
 [[package]]
 name = "syn"
@@ -1800,6 +1850,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "static_assertions",
+]
+
+[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1949,6 +2009,19 @@ name = "wasm-bindgen-shared"
 version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "web-sys"
@@ -2151,4 +2224,33 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zstd"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a27595e173641171fc74a1232b7b1c7a7cb6e18222c11e9dfb9888fa424c53c"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "6.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee98ffd0b48ee95e6c5168188e44a54550b1564d9d530ee21d5f0eaed1069581"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.12+zstd.1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a4e40c320c3cb459d9a9ff6de98cff88f4751ee9275d140e2be94a2b74e4c13"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "geomedea"
 version = "0.3.0-beta.2"
-source = "git+https://github.com/michaelkirk/geomedea#127b96c9ee38b33cb9391876227626e7224df0b4"
+source = "git+https://github.com/michaelkirk/geomedea#417d4f43cd35aa98aea19a0b17632c8309b50466"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1667,9 +1667,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "streaming-http-range-client"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66ff5fba23ab8761b13d09408a99a1de5699bafa10725549031f642dda5f37d"
+checksum = "c36485450d6c5dce07e80f19435ceab2c8c581f58582cf38f0f0d93f9efd585d"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -16,10 +16,11 @@ chrono = { version = "0.4.33", default-features = false, features = ["serde"] }
 csv = "1.3.0"
 enum-map = { version = "2.7.3", features = ["serde"] }
 fast_paths = "1.0.0"
-flatgeobuf = "4.2.1"
+futures-util = { version ="0.3.30", default-features = false }
 geo = "0.28.0"
 geojson = { git = "https://github.com/georust/geojson", features = ["geo-types"] }
-geozero = { version = "0.13.0", default-features = false, features = ["with-geo"] }
+geomedea = { git = "https://github.com/michaelkirk/geomedea", default-features = false }
+itertools = "0.13.0"
 js-sys = "0.3.69"
 log = "0.4.20"
 muv-osm = { git = "https://gitlab.com/LeLuxNet/Muv", features = ["lanes"] }
@@ -34,10 +35,9 @@ wasm-bindgen = "0.2.87"
 wasm-bindgen-futures = "0.4.42"
 web-sys = { version = "0.3.64", features = ["console"] }
 web-time = "1.1.0"
-miniz_oxide = "0.7.4"
-itertools = "0.13.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+geomedea = { git = "https://github.com/michaelkirk/geomedea" }
 tokio = { version = "1.38.0", features = ["macros", "rt-multi-thread"] }
 
 # For local development, build dependencies in release mode once, but otherwise

--- a/backend/src/gtfs/mod.rs
+++ b/backend/src/gtfs/mod.rs
@@ -10,7 +10,7 @@ use self::ids::orig_ids;
 pub use self::ids::{RouteID, StopID, TripID};
 use crate::graph::RoadID;
 
-mod fgb;
+mod gmd;
 mod ids;
 mod scrape;
 

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -50,7 +50,8 @@ impl MapModel {
         // Panics shouldn't happen, but if they do, console.log them.
         console_error_panic_hook::set_once();
         START.call_once(|| {
-            console_log::init_with_level(log::Level::Info).unwrap();
+            // TODO Debugging geomedea
+            console_log::init_with_level(log::Level::Debug).unwrap();
         });
 
         let gtfs = match gtfs_url {

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -54,7 +54,7 @@ impl MapModel {
         });
 
         let gtfs = match gtfs_url {
-            Some(url) => GtfsSource::FGB(url),
+            Some(url) => GtfsSource::Geomedea(url),
             None => GtfsSource::None,
         };
         let graph = if is_osm {
@@ -218,6 +218,6 @@ fn err_to_js<E: std::fmt::Display>(err: E) -> JsValue {
 
 pub enum GtfsSource {
     Dir(String),
-    FGB(String),
+    Geomedea(String),
     None,
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -13,8 +13,7 @@ use backend::{Graph, GtfsSource, Timer};
 /// manual testing for now.
 #[tokio::main]
 async fn main() -> Result<()> {
-    // TODO Changed to Debug to check geomedea perf
-    simple_logger::init_with_level(log::Level::Debug).unwrap();
+    simple_logger::init_with_level(log::Level::Info).unwrap();
 
     let args: Vec<String> = std::env::args().collect();
     if args.len() < 3 || (args[1] != "graph" && args[1] != "gmd") {

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -13,13 +13,13 @@ use backend::{Graph, GtfsSource, Timer};
 /// manual testing for now.
 #[tokio::main]
 async fn main() -> Result<()> {
-    simple_logger::SimpleLogger::new().init().unwrap();
+    simple_logger::init_with_level(log::Level::Info).unwrap();
 
     let args: Vec<String> = std::env::args().collect();
-    if args.len() < 3 || (args[1] != "graph" && args[1] != "fgb") {
+    if args.len() < 3 || (args[1] != "graph" && args[1] != "gmd") {
         println!("Usage: one of these:");
         println!("To make a graph.bin: graph osm.pbf [gtfs_directory]");
-        println!("To make a gtfs.fgb: fgb gtfs_directory");
+        println!("To make a gtfs.gmd: gmd gtfs_directory");
         std::process::exit(1);
     }
 
@@ -34,12 +34,12 @@ async fn main() -> Result<()> {
         let graph = Graph::new(&osm_bytes, gtfs, timer).await?;
         let writer = BufWriter::new(File::create("graph.bin")?);
         bincode::serialize_into(writer, &graph)?;
-    } else if args[1] == "fgb" {
-        let mut timer = Timer::new("build fgb from gtfs", None);
+    } else if args[1] == "gmd" {
+        let mut timer = Timer::new("build geomedea from gtfs", None);
         timer.step("parse GTFS");
         let model = backend::GtfsModel::parse(&args[2], None)?;
-        timer.step("turn into FGB");
-        model.to_fgb("gtfs.fgb")?;
+        timer.step("turn into geomedea");
+        model.to_geomedea("gtfs.gmd")?;
         timer.done();
     }
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -13,7 +13,8 @@ use backend::{Graph, GtfsSource, Timer};
 /// manual testing for now.
 #[tokio::main]
 async fn main() -> Result<()> {
-    simple_logger::init_with_level(log::Level::Info).unwrap();
+    // TODO Changed to Debug to check geomedea perf
+    simple_logger::init_with_level(log::Level::Debug).unwrap();
 
     let args: Vec<String> = std::env::args().collect();
     if args.len() < 3 || (args[1] != "graph" && args[1] != "gmd") {

--- a/backend/src/scrape.rs
+++ b/backend/src/scrape.rs
@@ -137,7 +137,7 @@ impl Graph {
         timer.step("parse");
         let mut gtfs = match gtfs_source {
             GtfsSource::Dir(path) => GtfsModel::parse(&path, Some(&graph.mercator))?,
-            GtfsSource::FGB(url) => GtfsModel::from_fgb(&url, &graph.mercator).await?,
+            GtfsSource::Geomedea(url) => GtfsModel::from_geomedea(&url, &graph.mercator).await?,
             GtfsSource::None => GtfsModel::empty(),
         };
         snap_stops(&mut roads, &mut gtfs, &closest_road[Mode::Foot], &mut timer);

--- a/web/src/title/MapLoader.svelte
+++ b/web/src/title/MapLoader.svelte
@@ -61,7 +61,7 @@
   async function loadModel(buffer: ArrayBuffer) {
     let gtfsUrl = useLocalVite
       ? `http://${window.location.host}/15m/gtfs.gmd`
-      : "https://assets.od2net.org/severance_pbfs/gtfs.gmd";
+      : "https://assets.od2net.org/gtfs.gmd";
     loading = ["Building map model from OSM input"];
     console.time("load");
     await $backend!.loadOsmFile(

--- a/web/src/title/MapLoader.svelte
+++ b/web/src/title/MapLoader.svelte
@@ -60,8 +60,8 @@
 
   async function loadModel(buffer: ArrayBuffer) {
     let gtfsUrl = useLocalVite
-      ? `http://${window.location.host}/15m/gtfs.fgb`
-      : "https://assets.od2net.org/severance_pbfs/gtfs.fgb";
+      ? `http://${window.location.host}/15m/gtfs.gmd`
+      : "https://assets.od2net.org/severance_pbfs/gtfs.gmd";
     loading = ["Building map model from OSM input"];
     console.time("load");
     await $backend!.loadOsmFile(


### PR DESCRIPTION
CC @michaelkirk, I'm trying out geomedea for the use case I described in Discord!

| Metric  | flatgeobuffer | geomedea |
| --------- | ----------------- | -------------- |
| File size | 99MB         | 53MB |
| Bristol | 3.6MB in 23 requests | 5MB in 20 requests |
| Elephant & Castle | 6.4MB in 935 requests, 1.76 minutes | 9.4MB in 24 requests, 8.3s |

Bristol doesn't have many GTFS trip shapes intersecting the area, while E&C in London has loads.

Unless I'm measuring something wrong, the current approach with geomedea incurs more bandwidth, but through _way_ less requests and latency.