### PR TITLE
Add basic population layer from popgetter

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -120,6 +120,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,10 +156,12 @@ dependencies = [
  "csv",
  "enum-map",
  "fast_paths",
+ "flatgeobuf",
  "futures-util",
  "geo",
  "geojson",
  "geomedea",
+ "geozero",
  "itertools 0.13.0",
  "js-sys",
  "log",
@@ -194,6 +202,12 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bincode"
@@ -539,6 +553,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fast_paths"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -556,6 +576,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
+name = "flatbuffers"
+version = "24.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8add37afff2d4ffa83bc748a70b4b1370984f6980768554182424ef71447c35f"
+dependencies = [
+ "bitflags 1.3.2",
+ "rustc_version",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -563,6 +593,23 @@ checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "flatgeobuf"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83c07a71b9a55179feef8a6cf75e8f8021b1f5611ee4d8092fabc5fd52c2a9ce"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "fallible-streaming-iterator",
+ "flatbuffers",
+ "geozero",
+ "http-range-client",
+ "log",
+ "reqwest 0.12.5",
+ "tempfile",
 ]
 
 [[package]]
@@ -746,6 +793,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "geozero"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cd8fb67347739a057fd607b6d8b43ba4ed93619ed84b8f429fa3296f8ae504c"
+dependencies = [
+ "geo-types",
+ "log",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -773,7 +832,26 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
+ "indexmap 2.2.6",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
  "indexmap 2.2.6",
  "slab",
  "tokio",
@@ -858,14 +936,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
  "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-range-client"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bae68ca93886cdaad288a3172f8157ce99ffb621343832b6254b79b4d7e8a34f"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "read-logger",
+ "reqwest 0.12.5",
+ "thiserror",
 ]
 
 [[package]]
@@ -890,9 +1016,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -905,16 +1031,89 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.5",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper 1.4.1",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper",
+ "hyper 0.14.29",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "hyper 1.4.1",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1341,6 +1540,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1535,6 +1754,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "read-logger"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7f715a23c7db804b71eb9162a9cf210b89e99db9c3649a2a038d13b7594a99"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1578,16 +1806,16 @@ version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-tls",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.29",
+ "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
  "log",
@@ -1596,11 +1824,11 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
@@ -1611,7 +1839,65 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "winreg",
+ "winreg 0.50.0",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.4.5",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-rustls",
+ "hyper-tls 0.6.0",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile 2.1.3",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.1",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg 0.52.0",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1651,6 +1937,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1664,12 +1959,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64",
+ "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
+dependencies = [
+ "base64 0.22.1",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1733,6 +2068,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
@@ -1857,6 +2198,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1879,10 +2226,16 @@ dependencies = [
  "bytes",
  "futures-util",
  "log",
- "reqwest",
+ "reqwest 0.11.27",
  "tokio",
  "tokio-util",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1900,6 +2253,12 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
 name = "system-configuration"
@@ -2028,6 +2387,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+dependencies = [
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2039,6 +2409,27 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
@@ -2119,6 +2510,12 @@ name = "unicode-width"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -2476,6 +2873,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2515,6 +2922,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zstd"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -20,6 +20,7 @@ futures-util = { version ="0.3.30", default-features = false }
 geo = "0.28.0"
 geojson = { git = "https://github.com/georust/geojson", features = ["geo-types"] }
 geomedea = { git = "https://github.com/michaelkirk/geomedea", default-features = false }
+geozero = { version = "0.13.0", default-features = false, features = ["with-geo"] }
 itertools = "0.13.0"
 js-sys = "0.3.69"
 log = "0.4.20"
@@ -35,6 +36,7 @@ wasm-bindgen = "0.2.87"
 wasm-bindgen-futures = "0.4.42"
 web-sys = { version = "0.3.64", features = ["console"] }
 web-time = "1.1.0"
+flatgeobuf = "4.3.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 geomedea = { git = "https://github.com/michaelkirk/geomedea" }

--- a/backend/src/graph/mod.rs
+++ b/backend/src/graph/mod.rs
@@ -7,7 +7,7 @@ mod transit_route;
 
 use anyhow::Result;
 use enum_map::{Enum, EnumMap};
-use geo::{Coord, LineLocatePoint, LineString, Point, Polygon};
+use geo::{Coord, LineLocatePoint, LineString, MultiPolygon, Point, Polygon};
 use geojson::{Feature, GeoJson, Geometry};
 use rstar::{primitives::GeomWithData, RTree};
 use serde::{Deserialize, Serialize};
@@ -32,6 +32,8 @@ pub struct Graph {
     pub amenities: Vec<Amenity>,
 
     pub gtfs: GtfsModel,
+
+    pub zones: Vec<Zone>,
 }
 
 pub type EdgeLocation = GeomWithData<LineString, RoadID>;
@@ -237,4 +239,11 @@ pub enum PathStep {
         trip: TripID,
         stop2: StopID,
     },
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Zone {
+    pub geom: MultiPolygon,
+    // TODO Later on, this could be generic or user-supplied
+    pub population: u32,
 }

--- a/backend/src/graph/mod.rs
+++ b/backend/src/graph/mod.rs
@@ -186,6 +186,17 @@ impl Graph {
             intersection,
         }
     }
+
+    /// Returns a GeoJSON string
+    pub fn render_zones(&self) -> Result<String> {
+        let mut features = Vec::new();
+        for zone in &self.zones {
+            let mut f = Feature::from(Geometry::from(&self.mercator.to_wgs84(&zone.geom)));
+            f.set_property("population", zone.population);
+            features.push(f);
+        }
+        Ok(serde_json::to_string(&GeoJson::from(features))?)
+    }
 }
 
 impl Road {

--- a/backend/src/graph/scrape.rs
+++ b/backend/src/graph/scrape.rs
@@ -301,9 +301,12 @@ async fn load_zones(url: String, mercator: &Mercator) -> Result<Vec<Zone>> {
     let mut zones = Vec::new();
     while let Some(feature) = fgb.next().await? {
         // TODO Could intersect with boundary_polygon, but some extras nearby won't hurt anything
+        let mut geom = get_multipolygon(feature)?;
+        mercator.to_mercator_in_place(&mut geom);
         zones.push(Zone {
-            geom: get_multipolygon(feature)?,
-            population: feature.property("population")?,
+            geom,
+            // TODO Re-encode as UInt
+            population: feature.property::<i64>("population")?.try_into()?,
         });
     }
     Ok(zones)

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -94,6 +94,11 @@ impl MapModel {
         vec![b.min().x, b.min().y, b.max().x, b.max().y]
     }
 
+    #[wasm_bindgen(js_name = renderZones)]
+    pub fn render_zones(&self) -> Result<String, JsValue> {
+        self.graph.render_zones().map_err(err_to_js)
+    }
+
     #[wasm_bindgen(js_name = isochrone)]
     pub fn isochrone(&self, input: JsValue) -> Result<String, JsValue> {
         let req: IsochroneRequest = serde_wasm_bindgen::from_value(input)?;

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -12,7 +12,7 @@ use geo::Coord;
 use serde::Deserialize;
 use wasm_bindgen::prelude::*;
 
-pub use graph::{Graph, Mode};
+pub use graph::{Graph, GtfsSource, Mode};
 pub use gtfs::GtfsModel;
 pub use timer::Timer;
 
@@ -40,6 +40,7 @@ impl MapModel {
         input_bytes: &[u8],
         is_osm: bool,
         gtfs_url: Option<String>,
+        population_url: Option<String>,
         progress_cb: Option<js_sys::Function>,
     ) -> Result<MapModel, JsValue> {
         // Panics shouldn't happen, but if they do, console.log them.
@@ -54,9 +55,14 @@ impl MapModel {
             None => graph::GtfsSource::None,
         };
         let graph = if is_osm {
-            Graph::new(input_bytes, gtfs, Timer::new("build graph", progress_cb))
-                .await
-                .map_err(err_to_js)?
+            Graph::new(
+                input_bytes,
+                gtfs,
+                population_url,
+                Timer::new("build graph", progress_cb),
+            )
+            .await
+            .map_err(err_to_js)?
         } else {
             bincode::deserialize_from(input_bytes).map_err(err_to_js)?
         };

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -23,6 +23,9 @@ async fn main() -> Result<()> {
         std::process::exit(1);
     }
 
+    // TODO Hardcoded for now
+    let population_url = Some("https://assets.od2net.org/population.fgb".to_string());
+
     if args[1] == "graph" {
         let timer = Timer::new("build graph", None);
         let osm_bytes = std::fs::read(&args[2])?;
@@ -31,7 +34,7 @@ async fn main() -> Result<()> {
             None => GtfsSource::None,
         };
 
-        let graph = Graph::new(&osm_bytes, gtfs, timer).await?;
+        let graph = Graph::new(&osm_bytes, gtfs, population_url, timer).await?;
         let writer = BufWriter::new(File::create("graph.bin")?);
         bincode::serialize_into(writer, &graph)?;
     } else if args[1] == "gmd" {

--- a/data_prep/.gitignore
+++ b/data_prep/.gitignore
@@ -1,0 +1,1 @@
+*.geojson

--- a/data_prep/population.sh
+++ b/data_prep/population.sh
@@ -21,7 +21,8 @@ $POPGETTER data \
         --geometry-level oa \
         --id 1355501cf6f3b1fa8cf6a100c98f330d51a3382ed2111fef0d2fff446608a428
 mapshaper england_raw.geojson \
-        -each 'population="Residence type: Total; measures: Value", delete GEO_ID' \
+        -rename-fields population='Residence type: Total; measures: Value' \
+        -each 'delete GEO_ID' \
         -proj init=EPSG:27700 crs=wgs84 \
         -o england.geojson
 
@@ -33,7 +34,8 @@ $POPGETTER data \
         --geometry-level statistical_sector \
         --id fcf09809889c1d9715bff5f825b0c6ed4d9286f2e2b4948839accc29c15e98c5
 mapshaper belgium_raw.geojson \
-        -each 'population="TOTAL", delete GEO_ID' \
+        -rename-fields population='TOTAL' \
+        -each 'delete GEO_ID' \
         -proj init=EPSG:3812 crs=wgs84 \
         -o belgium.geojson
 
@@ -46,7 +48,8 @@ $POPGETTER data \
         --geometry-level block_group \
         --id d23e348af6ab03265b4f258178edc6b509651095f81b965c1a62396fe463d0f6
 mapshaper usa_raw.geojson \
-        -each 'population="B01001_E001", delete GEO_ID' \
+        -rename-fields population='B01001_E001' \
+        -each 'delete GEO_ID' \
         -o usa.geojson
 
 # Scotland

--- a/data_prep/population.sh
+++ b/data_prep/population.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# This script prepares a consolidated FGB file with total population count in
+# the most granular zone for different countries, using
+# https://github.com/Urban-Analytics-Technology-Platform/popgetter. This script
+# / process might live elsewhere at some point.
+
+set -e
+set -x
+
+# You need to build https://github.com/Urban-Analytics-Technology-Platform/popgetter-cli
+POPGETTER=/home/dabreegster/Downloads/popgetter-cli/target/release/popgetter
+
+# The metrics and coordinate systems were figured out manually. In the future,
+# this'll be easier with a popgetter web UI.
+
+# England
+$POPGETTER data \
+        --force-run \
+        --output-format geojson \
+        --output-file england_raw.geojson \
+        --geometry-level oa \
+        --id 1355501cf6f3b1fa8cf6a100c98f330d51a3382ed2111fef0d2fff446608a428
+mapshaper england_raw.geojson \
+        -each 'population="Residence type: Total; measures: Value", delete GEO_ID' \
+        -proj init=EPSG:27700 crs=wgs84 \
+        -o england.geojson
+
+# Belgium
+$POPGETTER data \
+        --force-run \
+        --output-format geojson \
+        --output-file belgium_raw.geojson \
+        --geometry-level statistical_sector \
+        --id fcf09809889c1d9715bff5f825b0c6ed4d9286f2e2b4948839accc29c15e98c5
+mapshaper belgium_raw.geojson \
+        -each 'population="TOTAL", delete GEO_ID' \
+        -proj init=EPSG:3812 crs=wgs84 \
+        -o belgium.geojson
+
+# USA
+# TODO This might not be the right variable, and it's only at block_group
+$POPGETTER data \
+        --force-run \
+        --output-format geojson \
+        --output-file usa_raw.geojson \
+        --geometry-level block_group \
+        --id d23e348af6ab03265b4f258178edc6b509651095f81b965c1a62396fe463d0f6
+mapshaper usa_raw.geojson \
+        -each 'population="B01001_E001", delete GEO_ID' \
+        -o usa.geojson
+
+# Scotland
+# TODO
+
+# Northern Ireland
+# TODO
+
+# Merge files. You need to build https://github.com/acteng/will-it-fit/tree/main/data_prep/merge_files
+MERGER=/home/dabreegster/will-it-fit/data_prep/merge_files/target/release/merge_files
+$MERGER england.geojson belgium.geojson usa.geojson
+# Hosting: mv out.fgb ~/cloudflare_sync/population.fgb, sync it

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -29,11 +29,13 @@
     showAbout,
     routeA,
     routeB,
+    showPopulation,
   } from "./stores";
   import TitleMode from "./title/TitleMode.svelte";
   import workerWrapper from "./worker?worker";
   import { type Backend } from "./worker";
   import * as Comlink from "comlink";
+        import { PopulationLayer } from "./common";
 
   onMount(async () => {
     // If you get "import declarations may only appear at top level of a
@@ -165,6 +167,10 @@
           />
         {:else if $mode.kind == "buffer-route"}
           <BufferRouteMode gj={$mode.gj} />
+        {/if}
+
+        {#if $showPopulation}
+                <PopulationLayer />
         {/if}
       {/if}
     </MapLibre>

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -35,7 +35,7 @@
   import workerWrapper from "./worker?worker";
   import { type Backend } from "./worker";
   import * as Comlink from "comlink";
-        import { PopulationLayer } from "./common";
+  import { PopulationLayer } from "./common";
 
   onMount(async () => {
     // If you get "import declarations may only appear at top level of a
@@ -170,7 +170,7 @@
         {/if}
 
         {#if $showPopulation}
-                <PopulationLayer />
+          <PopulationLayer />
         {/if}
       {/if}
     </MapLibre>

--- a/web/src/BufferRouteMode.svelte
+++ b/web/src/BufferRouteMode.svelte
@@ -25,7 +25,7 @@
     <GeoJSON data={gj}>
       <LineLayer
         paint={{
-          "line-width": 20,
+          "line-width": ["case", ["==", ["get", "kind"], "route"], 20, 3],
           "line-color": [
             "case",
             ["==", ["get", "kind"], "route"],

--- a/web/src/BufferRouteMode.svelte
+++ b/web/src/BufferRouteMode.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
   import { GeoJSON, LineLayer } from "svelte-maplibre";
   import { SplitComponent } from "svelte-utils/top_bar_layout";
-  import { mode } from "./stores";
   import type { FeatureCollection } from "geojson";
   import { makeColorRamp, Popup } from "svelte-utils/map";
   import { SequentialLegend } from "svelte-utils";
   import { colorScale } from "./colors";
+  import { NavBar } from "./common";
 
   export let gj: FeatureCollection;
 
@@ -14,9 +14,7 @@
 </script>
 
 <SplitComponent>
-  <div slot="top">
-    <button on:click={() => ($mode = { kind: "route" })}>Back</button>
-  </div>
+  <div slot="top"><NavBar /></div>
   <div slot="sidebar">
     <h2>Buffer around a route</h2>
     <SequentialLegend {colorScale} limits={limitsMinutes} />

--- a/web/src/IsochroneMode.svelte
+++ b/web/src/IsochroneMode.svelte
@@ -26,7 +26,7 @@
       lat: lerp(0.5, bbox[1], bbox[3]),
     };
   });
-  let contours = true;
+  let contours = false;
 
   let isochroneGj: FeatureCollection | null = null;
   let routeGj: FeatureCollection | null = null;
@@ -142,7 +142,7 @@
           id="isochrone"
           filter={isLine}
           paint={{
-            "line-width": 20,
+            "line-width": 2,
             "line-color": makeColorRamp(
               ["get", "cost_seconds"],
               limitsSeconds,

--- a/web/src/common/NavBar.svelte
+++ b/web/src/common/NavBar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { mode } from "../stores";
+  import { mode, showPopulation } from "../stores";
 </script>
 
 <nav>
@@ -39,3 +39,6 @@
     </li>
   </ul>
 </nav>
+
+<label><input type="checkbox" bind:checked={$showPopulation} />Population</label
+>

--- a/web/src/common/PopulationLayer.svelte
+++ b/web/src/common/PopulationLayer.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
-  import { GeoJSON, LineLayer, FillLayer, hoverStateFilter } from "svelte-maplibre";
+  import {
+    GeoJSON,
+    LineLayer,
+    FillLayer,
+    hoverStateFilter,
+  } from "svelte-maplibre";
   import { notNull } from "svelte-utils";
   import { Popup } from "svelte-utils/map";
   import { backend } from "../stores";
@@ -11,12 +16,12 @@
       manageHoverState
       paint={{
         "fill-color": "red",
-        "fill-opacity": hoverStateFilter(0.5, 0.8),
+        "fill-opacity": hoverStateFilter(0.2, 0.8),
       }}
     >
       <Popup openOn="hover" let:props>{props.population.toLocaleString()}</Popup
       >
     </FillLayer>
-    <LineLayer paint={{"line-color": "black", "line-width": 1}} />
+    <LineLayer paint={{ "line-color": "black", "line-width": 1 }} />
   </GeoJSON>
 {/await}

--- a/web/src/common/PopulationLayer.svelte
+++ b/web/src/common/PopulationLayer.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  import { GeoJSON, LineLayer, FillLayer, hoverStateFilter } from "svelte-maplibre";
+  import { notNull } from "svelte-utils";
+  import { Popup } from "svelte-utils/map";
+  import { backend } from "../stores";
+</script>
+
+{#await notNull($backend).renderZones() then data}
+  <GeoJSON {data} generateId>
+    <FillLayer
+      manageHoverState
+      paint={{
+        "fill-color": "red",
+        "fill-opacity": hoverStateFilter(0.5, 0.8),
+      }}
+    >
+      <Popup openOn="hover" let:props>{props.population.toLocaleString()}</Popup
+      >
+    </FillLayer>
+    <LineLayer paint={{"line-color": "black", "line-width": 1}} />
+  </GeoJSON>
+{/await}

--- a/web/src/common/index.ts
+++ b/web/src/common/index.ts
@@ -4,4 +4,5 @@ export { default as Loading } from "./Loading.svelte";
 export { default as NavBar } from "./NavBar.svelte";
 export { default as PickAmenityKinds } from "./PickAmenityKinds.svelte";
 export { default as PickTravelMode } from "./PickTravelMode.svelte";
+export { default as PopulationLayer } from "./PopulationLayer.svelte";
 export { default as StopsLayer } from "./StopsLayer.svelte";

--- a/web/src/stores.ts
+++ b/web/src/stores.ts
@@ -28,6 +28,7 @@ export type Mode =
 export let mode: Writable<Mode> = writable({ kind: "title" });
 export let map: Writable<Map | null> = writable(null);
 export let showAbout: Writable<boolean> = writable(true);
+export let showPopulation: Writable<boolean> = writable(false);
 
 export type TravelMode = "car" | "bicycle" | "foot" | "transit";
 

--- a/web/src/title/MapLoader.svelte
+++ b/web/src/title/MapLoader.svelte
@@ -62,11 +62,15 @@
     let gtfsUrl = useLocalVite
       ? `http://${window.location.host}/15m/gtfs.gmd`
       : "https://assets.od2net.org/gtfs.gmd";
+    let populationUrl = useLocalVite
+      ? `http://${window.location.host}/15m/population.fgb`
+      : "https://assets.od2net.org/population.fgb";
     loading = ["Building map model from OSM input"];
     console.time("load");
     await $backend!.loadOsmFile(
       new Uint8Array(buffer),
       gtfsUrl,
+      populationUrl,
       Comlink.proxy(progressCb),
     );
     console.timeEnd("load");

--- a/web/src/worker.ts
+++ b/web/src/worker.ts
@@ -25,7 +25,13 @@ export class Backend {
     // TODO Do we need to do this only once?
     await init();
 
-    this.inner = await new MapModel(osmBytes, true, gtfsUrl, populationUrl, progressCb);
+    this.inner = await new MapModel(
+      osmBytes,
+      true,
+      gtfsUrl,
+      populationUrl,
+      progressCb,
+    );
   }
 
   async loadGraphFile(graphBytes: Uint8Array) {
@@ -34,7 +40,13 @@ export class Backend {
 
     // No progress worth reporting for this
     // TODO Can we await here?
-    this.inner = await new MapModel(graphBytes, false, undefined, undefined, undefined);
+    this.inner = await new MapModel(
+      graphBytes,
+      false,
+      undefined,
+      undefined,
+      undefined,
+    );
   }
 
   isLoaded(): boolean {
@@ -80,6 +92,14 @@ export class Backend {
     }
 
     return JSON.parse(this.inner.renderAmenities());
+  }
+
+  renderZones(): FeatureCollection {
+    if (!this.inner) {
+      throw new Error("Backend used without a file loaded");
+    }
+
+    return JSON.parse(this.inner.renderZones());
   }
 
   isochrone(req: {

--- a/web/src/worker.ts
+++ b/web/src/worker.ts
@@ -19,13 +19,13 @@ export class Backend {
   async loadOsmFile(
     osmBytes: Uint8Array,
     gtfsUrl: string | undefined,
+    populationUrl: string | undefined,
     progressCb: (msg: string) => void,
   ) {
     // TODO Do we need to do this only once?
     await init();
 
-    // TODO Can we await here?
-    this.inner = await new MapModel(osmBytes, true, gtfsUrl, progressCb);
+    this.inner = await new MapModel(osmBytes, true, gtfsUrl, populationUrl, progressCb);
   }
 
   async loadGraphFile(graphBytes: Uint8Array) {
@@ -34,7 +34,7 @@ export class Backend {
 
     // No progress worth reporting for this
     // TODO Can we await here?
-    this.inner = await new MapModel(graphBytes, false, undefined, undefined);
+    this.inner = await new MapModel(graphBytes, false, undefined, undefined, undefined);
   }
 
   isLoaded(): boolean {


### PR DESCRIPTION
#6

I've used https://github.com/Urban-Analytics-Technology-Platform/popgetter to generate a flatgeobuf file with total population count in 3 countries, and am starting to import/display it here. Try https://a-b-street.github.io/15m/ anywhere in England, USA, or Belgium, and use the top-right control:
![image](https://github.com/user-attachments/assets/6ab77e1c-489c-4646-a60a-b162d95123e6)

Next steps are improving this display (coloring by population density) and incorporating in all of the tools. When there's an isochrone around a point or a network buffer around a route, intersect it with the census polygons and sum up population totals.

Right now it's just showing a total population count, but there's endless questions somebody might want to ask. Maybe there could be more direct integration with popgetter to show any metric, or maybe they should still be curated based on specific use cases.

CC @michaelkirk -- full circle, the fgb US census layer in A/B Street makes a reappearance :)